### PR TITLE
improve finding a meaningful base image name for layout summary page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,5 @@ test-image:
 
 .PHONY: clean
 clean:
+	stacker clean
 	rm -rf ociv

--- a/knowntags.go
+++ b/knowntags.go
@@ -22,12 +22,11 @@ var LayerNameMap = map[string][]string{}
 // todo: be nice if this did a smart shortening, like replacing names with common prefixes and tags like
 // foo.com/{imageone,imagetwo}:commontag
 
-func getShortNamesForHash(digest string) []string {
+func getShortStringForNames(names []string) []string {
 	// map from tag-> names
 	namesWithCommonTags := map[string][]string{}
 	truncatedLayerNames := []string{}
 
-	names := getNamesForHash(digest)
 	if len(names) == 1 {
 		return names
 	}

--- a/ociutils.go
+++ b/ociutils.go
@@ -184,7 +184,7 @@ func getImageInfoString(ref imageref, info imageInfo) string {
 			uncompressedSizeAnnotation = fmt.Sprintf("%d", val)
 		}
 
-		var layerNames = getShortNamesForHash(digest)
+		var layerNames = getShortStringForNames(getNamesForHash(digest))
 
 		diffIDHash := "-"
 		if len(info.config.RootFS.DiffIDs) > idx {


### PR DESCRIPTION
In cases where a base image has more than one layer:

- 1a1a1a1
- 2222222 : tagged here as common-base

then all images built with it will have an untagged layer[0], in which
case the summary can make it hard to identify what base image is
actually being used.

This commit adds some logic to build up the tree of layers, and if a
layer has some unique descendant that is tagged, we will display that
tag as the "base image name".

If there is no unique tagged descendant, we still use ?. This covers
most cases, but future work might want to find which path we are on and
find the unique earliest tag there
