### PR TITLE
make: move ociv back to default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,15 @@ TOOLSDIR := $(TOP_LEVEL)/tools
 GOLINTER_VERSION := v1.54.2
 GOLINTER := $(TOOLSDIR)/bin/golangci-lint
 
+
+ociv: *.go lint
+	CGO_ENABLED=0 go build ${LDFLAGS} ${GOTAGS} -o ociv  ./...
+
 $(GOLINTER):
 	mkdir -p $(TOOLSDIR)/bin
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOLSDIR)/bin $(GOLINTER_VERSION)
 	$(GOLINTER) version
 
-ociv: *.go
-	CGO_ENABLED=0 go build ${LDFLAGS} ${GOTAGS} -o ociv  ./...
 
 lint: *.go $(GOLINTER)
 	$(GOLINTER) run --out-format=colored-line-number


### PR DESCRIPTION
top target is default when you just run `make`
also have ociv depend on the lint target