### PR TITLE
better layer contents caching, squash support

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Build Static
       run: make ociv
     - name: upload binary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ociv
         path: ociv

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -18,9 +18,3 @@ jobs:
       with:
         name: ociv
         path: ociv
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Lint Go Code
-      run: make lint

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ GOLINTER_VERSION := v1.54.2
 GOLINTER := $(TOOLSDIR)/bin/golangci-lint
 
 
-ociv: *.go lint
+ociv: *.go
+	go env
 	CGO_ENABLED=0 go build ${LDFLAGS} ${GOTAGS} -o ociv  ./...
 
 $(GOLINTER):


### PR DESCRIPTION
now layer contents display supports squashfs mediatypes.

layer contents are cached less dumb-ly now. we get the full file list once and just grep it when the filter changes, instead of having to do all the file list IO on every filter change.